### PR TITLE
Added the option to utilise Ganglia on EMR. 

### DIFF
--- a/CrossbowIface.pm
+++ b/CrossbowIface.pm
@@ -86,7 +86,7 @@ our $emrArgs = "";
 our $noLogs = 0;
 our $logs = "";
 our $noEmrDebugging = 0;
-our $ganglia = 0;
+our $ganglia = "";
 
 # Job params
 our $input  = "";
@@ -329,7 +329,7 @@ GetOptions (
 	"logs:s"                    => \$logs,
 	"no-emr-debug"              => \$noEmrDebugging,
 	"swap:i"                    => \$swap,
-	"ganglia"					=> \$ganglia,
+	"ganglia:s"					=> \$ganglia,
 # Job params
 	"input:s"                   => \$input,
 	"output:s"                  => \$output,
@@ -1451,8 +1451,15 @@ my $cmdJson = "$emrScript ".
     "--bootstrap-name \"Add Swap\" ".
     "--args \"$swap\"";
 
-if($ganglia && (!$localJob && !$hadoopJob)) {
-	$cmdJson .= " --bootstrap-action s3://elasticmapreduce/bootstrap-actions/install-ganglia --bootstrap-name \"Install Ganglia\"";
+if(!$localJob && !$hadoopJob) {
+	$msg->("GANGLIA $ganglia\n");
+	if($ganglia eq "") {
+		$cmdJson .= " --bootstrap-action s3://elasticmapreduce/bootstrap-actions/install-ganglia --bootstrap-name \"Install Ganglia\"";
+	} elsif(parse_url($ganglia) eq "s3") {
+		$cmdJson .= " --bootstrap-action $ganglia --bootstrap-name \"Install Ganglia\"";		
+	} else {
+		die "Ganglia install path needs to be s3";
+	}
 }
 
 my $cmdSh = "sh $runLocalFile";

--- a/CrossbowIface.pm
+++ b/CrossbowIface.pm
@@ -86,6 +86,7 @@ our $emrArgs = "";
 our $noLogs = 0;
 our $logs = "";
 our $noEmrDebugging = 0;
+our $ganglia = 0;
 
 # Job params
 our $input  = "";
@@ -328,6 +329,7 @@ GetOptions (
 	"logs:s"                    => \$logs,
 	"no-emr-debug"              => \$noEmrDebugging,
 	"swap:i"                    => \$swap,
+	"ganglia"					=> \$ganglia,
 # Job params
 	"input:s"                   => \$input,
 	"output:s"                  => \$output,
@@ -1448,6 +1450,10 @@ my $cmdJson = "$emrScript ".
     "--bootstrap-action s3://elasticmapreduce/bootstrap-actions/add-swap ".
     "--bootstrap-name \"Add Swap\" ".
     "--args \"$swap\"";
+
+if($ganglia && (!$localJob && !$hadoopJob)) {
+	$cmdJson .= " --bootstrap-action s3://elasticmapreduce/bootstrap-actions/install-ganglia --bootstrap-name \"Install Ganglia\"";
+}
 
 my $cmdSh = "sh $runLocalFile";
 my $cmdHadoop = "sh $runHadoopFile";

--- a/cb_emr
+++ b/cb_emr
@@ -54,8 +54,8 @@ Options (defaults in []):
                          debugging enables the "Debug" button in the AWS
                          Console.  User must have SimpleDB account when this is
                          *not* specified. [off]
-  --ganglia              Uses Amazons ganglia install bootstrap action. More info 
-                         available at: http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/UsingEMR_Ganglia.html
+  --ganglia              Installs ganglia on the EMR cluster. Script must be on 
+                         S3. [s3://elasticmapreduce/bootstrap-actions/install-ganglia]
 
  Job params (don't affect results):
 

--- a/cb_emr
+++ b/cb_emr
@@ -54,6 +54,8 @@ Options (defaults in []):
                          debugging enables the "Debug" button in the AWS
                          Console.  User must have SimpleDB account when this is
                          *not* specified. [off]
+  --ganglia              Uses Amazons ganglia install bootstrap action. More info 
+                         available at: http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/UsingEMR_Ganglia.html
 
  Job params (don't affect results):
 


### PR DESCRIPTION
Allows the user to install [Ganglia](http://ganglia.sourceforge.net/), by using either [Amazon's pre-built bootstrap action](http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/UsingEMR_Ganglia.html) or by allowing the user to specify a specific install script.
